### PR TITLE
fix docs following public release

### DIFF
--- a/source/ACCESS.md
+++ b/source/ACCESS.md
@@ -16,7 +16,7 @@ individual artificial neuronal models."
 
 (downloading)=
 ## Downloading the dataset
-All data are made available as a [DataLad collection (currently requires to be part of the cneuromod team)](https://github.com/courtois-neuromod/cneuromod) on github.
+All data are made available as a [DataLad collection](https://github.com/courtois-neuromod/cneuromod) on github in public repositories.
 [DataLad](https://www.datalad.org/) is a tool for versioning a large data structure in a git repository. The dataset can be explored without downloading the data, and it is easy to only download the subset of the data you need for your project.
 See the [DataLad handbook](http://handbook.datalad.org/en/latest/) for further information.
 


### PR DESCRIPTION
The doc mentionned that is required being part of the cneuromod org for dataset access, this is no longer necessary for released dataset with repos set as public. 